### PR TITLE
Add a overlapped_by_iter method in RangeMOC

### DIFF
--- a/src/moc/range/borrowed.rs
+++ b/src/moc/range/borrowed.rs
@@ -1,0 +1,50 @@
+use std::{marker::PhantomData, ops::Range};
+
+/// Re-export `Ordinal` not to be out-of-sync with cdshealpix version.
+pub use healpix::compass_point::{Ordinal, OrdinalMap, OrdinalSet};
+
+use crate::{
+  elemset::range::BorrowedMocRanges,
+  idx::Idx,
+  moc::{range::RangeRefMocIter, HasMaxDepth, NonOverlapping, RangeMOCIntoIterator, ZSorted},
+  qty::MocQty,
+};
+
+pub struct BorrowedRangeMOC<'a, T: Idx, Q: MocQty<T>> {
+  depth_max: u8,
+  ranges: BorrowedMocRanges<'a, T, Q>,
+}
+
+impl<'a, T: Idx, Q: MocQty<T>> BorrowedRangeMOC<'a, T, Q> {
+  pub fn new(depth_max: u8, ranges: BorrowedMocRanges<'a, T, Q>) -> Self {
+    Self { depth_max, ranges }
+  }
+}
+
+impl<'a, T: Idx, Q: MocQty<T>> HasMaxDepth for BorrowedRangeMOC<'a, T, Q> {
+  fn depth_max(&self) -> u8 {
+    self.depth_max
+  }
+}
+impl<'a, T: Idx, Q: MocQty<T>> ZSorted for BorrowedRangeMOC<'a, T, Q> {}
+impl<'a, T: Idx, Q: MocQty<T>> NonOverlapping for BorrowedRangeMOC<'a, T, Q> {}
+
+impl<'a, T: Idx, Q: MocQty<T>> RangeMOCIntoIterator<T> for BorrowedRangeMOC<'a, T, Q> {
+  type Qty = Q;
+  type IntoRangeMOCIter = RangeRefMocIter<'a, T, Self::Qty>;
+
+  fn into_range_moc_iter(self) -> Self::IntoRangeMOCIter {
+    let l = self.ranges.0 .0.len();
+    let last: Option<Range<T>> = if l > 0 {
+      Some(self.ranges.0 .0[l - 1].clone())
+    } else {
+      None
+    };
+    RangeRefMocIter {
+      depth_max: self.depth_max,
+      iter: self.ranges.0 .0.iter(),
+      last,
+      _qty: PhantomData,
+    }
+  }
+}

--- a/src/moc/range/borrowed.rs
+++ b/src/moc/range/borrowed.rs
@@ -1,8 +1,5 @@
 use std::{marker::PhantomData, ops::Range};
 
-/// Re-export `Ordinal` not to be out-of-sync with cdshealpix version.
-pub use healpix::compass_point::{Ordinal, OrdinalMap, OrdinalSet};
-
 use crate::{
   elemset::range::BorrowedMocRanges,
   idx::Idx,

--- a/src/moc/range/mod.rs
+++ b/src/moc/range/mod.rs
@@ -47,6 +47,7 @@ use crate::{
       minus::{minus, MinusRangeIter},
       multi_op::kway_or,
       or::{or, OrRangeIter},
+      overlap::{overlapped_by, OverlapRangeIter},
       xor::xor,
     },
     CellMOCIntoIterator, CellMOCIterator, CellOrCellRangeMOCIterator, HasMaxDepth, MOCProperties,
@@ -329,6 +330,11 @@ impl<T: Idx, Q: MocQty<T>> RangeMOC<T, Q> {
     RangeMOC::new(depth_max, ranges)
   }
 
+  /// Returns an iterator over the ranges of self that are overlapping the rhs range MOC
+  pub fn overlapped_by_iter<'a>(&'a self, rhs: &'a RangeMOC<T, Q>) -> OverlappedByIter<'_, T, Q> {
+    overlapped_by(self.into_range_moc_iter(), rhs.into_range_moc_iter())
+  }
+
   // CONTAINS: union that stops at first elem found
   // OVERLAP (=!CONTAINS on the COMPLEMENT ;) )
 
@@ -427,6 +433,10 @@ pub type ExtBorderIter<'a, T> =
 /// Complex type returned by the `internal_border_iter` method.
 pub type IntBorderIter<'a, T> =
   AndRangeIter<T, Hpx<T>, RangeMocIter<T, Hpx<T>>, RangeRefMocIter<'a, T, Hpx<T>>>;
+
+/// Complex type returned by the `internal_border_iter` method.
+pub type OverlappedByIter<'a, T, Q> =
+  OverlapRangeIter<T, Q, RangeRefMocIter<'a, T, Q>, RangeRefMocIter<'a, T, Q>>;
 
 impl<T: Idx> RangeMOC<T, Hpx<T>> {
   /// Returns `true` if the given coordinates (in radians) is in the MOC

--- a/src/moc/range/mod.rs
+++ b/src/moc/range/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+  cmp::Ordering,
   convert::{TryFrom, TryInto},
   error::Error,
   fs::File,
@@ -7,7 +8,7 @@ use std::{
   num::TryFromIntError,
   ops::Range,
   path::Path,
-  slice,
+  slice::SliceIndex,
   vec::IntoIter,
 };
 
@@ -41,14 +42,17 @@ use crate::{
       maxdepth_range::RangeMocBuilder,
     },
     cell::CellMOC,
-    range::op::{
-      and::{and, AndRangeIter},
-      merge::merge_sorted,
-      minus::{minus, MinusRangeIter},
-      multi_op::kway_or,
-      or::{or, OrRangeIter},
-      overlap::{overlapped_by, OverlapRangeIter},
-      xor::xor,
+    range::{
+      borrowed::BorrowedRangeMOC,
+      op::{
+        and::{and, AndRangeIter},
+        merge::merge_sorted,
+        minus::{minus, MinusRangeIter},
+        multi_op::kway_or,
+        or::{or, OrRangeIter},
+        overlap::{overlapped_by, OverlapRangeIter},
+        xor::xor,
+      },
     },
     CellMOCIntoIterator, CellMOCIterator, CellOrCellRangeMOCIterator, HasMaxDepth, MOCProperties,
     NonOverlapping, RangeMOCIntoIterator, RangeMOCIterator, ZSorted,
@@ -56,7 +60,7 @@ use crate::{
   qty::{Bounded, Frequency, Hpx, MocQty, Time},
   ranges::{BorrowedRanges, Ranges, SNORanges},
 };
-
+pub mod borrowed;
 pub mod op;
 
 /// Structure made to draw MOCs in AladinLite.
@@ -145,6 +149,16 @@ impl<T: Idx, Q: MocQty<T>> RangeMOC<T, Q> {
       ranges: Ranges::new_unchecked(vec![range]).into(),
     }
   }
+  /// Similar to what's Vec does: https://doc.rust-lang.org/src/core/slice/mod.rs.html#617-619
+  pub fn select<'a, I>(&'a self, index: I) -> BorrowedRangeMOC<'a, T, Q>
+  where
+    I: SliceIndex<[Range<T>], Output = [Range<T>]>,
+  {
+    let r = &self.ranges.0 .0[index];
+    let br = BorrowedRanges(r);
+    BorrowedRangeMOC::new(self.depth_max, br.into())
+  }
+
   pub fn depth_max(&self) -> u8 {
     self.depth_max
   }
@@ -332,7 +346,39 @@ impl<T: Idx, Q: MocQty<T>> RangeMOC<T, Q> {
 
   /// Returns an iterator over the ranges of self that are overlapping the rhs range MOC
   pub fn overlapped_by_iter<'a>(&'a self, rhs: &'a RangeMOC<T, Q>) -> OverlappedByIter<'_, T, Q> {
-    overlapped_by(self.into_range_moc_iter(), rhs.into_range_moc_iter())
+    let l = &self.ranges.0 .0;
+    let r = &rhs.ranges.0 .0;
+
+    // Quick rejection test
+    let (il, ir) = if l.is_empty()
+      || r.is_empty()
+      || l[0].start >= r[r.len() - 1].end
+      || l[l.len() - 1].end <= r[0].start
+    {
+      (l.len() - 1, r.len() - 1)
+    } else {
+      // Use binary search to find the starting indices
+      match l[0].start.cmp(&r[0].start) {
+        Ordering::Less => {
+          let il = match l.binary_search_by(|l_range| l_range.start.cmp(&r[0].start)) {
+            Ok(i) => i,
+            Err(i) => i - 1,
+          };
+          (il, 0)
+        }
+        Ordering::Greater => {
+          let ir = match r.binary_search_by(|r_range| r_range.start.cmp(&l[0].start)) {
+            Ok(i) => i,
+            Err(i) => i - 1,
+          };
+          (0, ir)
+        }
+        Ordering::Equal => (0, 0),
+      }
+    };
+
+    let (left, right) = (self.select(il..), rhs.select(ir..));
+    overlapped_by(left.into_range_moc_iter(), right.into_range_moc_iter())
   }
 
   // CONTAINS: union that stops at first elem found
@@ -1443,7 +1489,7 @@ impl<T: Idx, Q: MocQty<T>> RangeMOCIntoIterator<T> for RangeMOC<T, Q> {
 /// Iterator borrowing the `RangeMOC` it iterates over.
 pub struct RangeRefMocIter<'a, T: Idx, Q: MocQty<T>> {
   depth_max: u8,
-  iter: slice::Iter<'a, Range<T>>,
+  iter: std::slice::Iter<'a, Range<T>>,
   last: Option<Range<T>>,
   _qty: PhantomData<Q>,
 }
@@ -1472,6 +1518,7 @@ impl<'a, T: Idx, Q: MocQty<T>> RangeMOCIterator<T> for RangeRefMocIter<'a, T, Q>
     self.last.as_ref()
   }
 }
+
 impl<'a, T: Idx, Q: MocQty<T>> RangeMOCIntoIterator<T> for &'a RangeMOC<T, Q> {
   type Qty = Q;
   type IntoRangeMOCIter = RangeRefMocIter<'a, T, Self::Qty>;

--- a/src/moc/range/mod.rs
+++ b/src/moc/range/mod.rs
@@ -149,6 +149,7 @@ impl<T: Idx, Q: MocQty<T>> RangeMOC<T, Q> {
       ranges: Ranges::new_unchecked(vec![range]).into(),
     }
   }
+
   /// Similar to what's Vec does: https://doc.rust-lang.org/src/core/slice/mod.rs.html#617-619
   pub fn select<'a, I>(&'a self, index: I) -> BorrowedRangeMOC<'a, T, Q>
   where
@@ -345,7 +346,7 @@ impl<T: Idx, Q: MocQty<T>> RangeMOC<T, Q> {
   }
 
   /// Returns an iterator over the ranges of self that are overlapping the rhs range MOC
-  pub fn overlapped_by_iter<'a>(&'a self, rhs: &'a RangeMOC<T, Q>) -> OverlappedByIter<'_, T, Q> {
+  pub fn overlapped_by_iter<'a>(&'a self, rhs: &'a RangeMOC<T, Q>) -> OverlappedByIter<'a, T, Q> {
     let l = &self.ranges.0 .0;
     let r = &rhs.ranges.0 .0;
 

--- a/src/moc/range/op/mod.rs
+++ b/src/moc/range/op/mod.rs
@@ -13,3 +13,5 @@ pub mod or; // <=> union
 pub mod xor; // <=> Aladin Difference
 
 pub mod multi_op;
+
+pub mod overlap;

--- a/src/moc/range/op/overlap.rs
+++ b/src/moc/range/op/overlap.rs
@@ -82,6 +82,7 @@ where
     self.left_it.depth_max()
   }
 }
+
 impl<T, Q, I1, I2> ZSorted for OverlapRangeIter<T, Q, I1, I2>
 where
   T: Idx,
@@ -98,6 +99,7 @@ where
   I2: RangeMOCIterator<T, Qty = Q>,
 {
 }
+
 impl<T, Q, I1, I2> MOCProperties for OverlapRangeIter<T, Q, I1, I2>
 where
   T: Idx,
@@ -106,6 +108,7 @@ where
   I2: RangeMOCIterator<T, Qty = Q>,
 {
 }
+
 impl<T, Q, I1, I2> Iterator for OverlapRangeIter<T, Q, I1, I2>
 where
   T: Idx,

--- a/src/moc/range/op/overlap.rs
+++ b/src/moc/range/op/overlap.rs
@@ -1,0 +1,227 @@
+use std::ops::Range;
+
+use crate::idx::Idx;
+use crate::moc::{HasMaxDepth, MOCProperties, NonOverlapping, RangeMOCIterator, ZSorted};
+use crate::qty::MocQty;
+
+/// Performs a logical `OR` between the two input iterators of ranges.
+pub fn overlapped_by<T, Q, I1, I2>(left_it: I1, right_it: I2) -> OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+  OverlapRangeIter::new(left_it, right_it)
+}
+
+/// Returns in a on-the-fly manner the ranges of `left_it` that overlap those in I2.
+pub struct OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+  left_it: I1,
+  right_it: I2,
+  left: Option<Range<T>>,
+  right: Option<Range<T>>,
+}
+
+impl<T, Q, I1, I2> OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+  fn new(mut left_it: I1, mut right_it: I2) -> OverlapRangeIter<T, Q, I1, I2> {
+    let left = left_it.next();
+    let right = right_it.next();
+
+    // Quick rejection tests
+    if let (Some(up_left), Some(low_right)) = (left_it.peek_last(), &right) {
+      if up_left.end <= low_right.start {
+        return OverlapRangeIter {
+          left_it,
+          right_it,
+          left: None,
+          right: None,
+        };
+      }
+    }
+    if let (Some(low_left), Some(up_right)) = (&left, right_it.peek_last()) {
+      if up_right.end <= low_left.start {
+        return OverlapRangeIter {
+          left_it,
+          right_it,
+          left: None,
+          right: None,
+        };
+      }
+    }
+    // Normal behaviour
+    OverlapRangeIter {
+      left_it,
+      right_it,
+      left,
+      right,
+    }
+  }
+}
+
+impl<T, Q, I1, I2> HasMaxDepth for OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+  fn depth_max(&self) -> u8 {
+    self.left_it.depth_max()
+  }
+}
+impl<T, Q, I1, I2> ZSorted for OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+}
+impl<T, Q, I1, I2> NonOverlapping for OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+}
+impl<T, Q, I1, I2> MOCProperties for OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+}
+impl<T, Q, I1, I2> Iterator for OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+  type Item = Range<T>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    while let (Some(l), Some(r)) = (&self.left, &self.right) {
+      if l.end <= r.start {
+        // |--l--| |--r--|
+        self.left = self.left_it.next();
+        while let Some(l) = &self.left {
+          if l.end <= r.start {
+            self.left = self.left_it.next();
+          } else {
+            break;
+          }
+        }
+      } else if r.end <= l.start {
+        // |--r--| |--l--|
+        self.right = self.right_it.next();
+        while let Some(r) = &self.right {
+          if r.end <= l.start {
+            self.right = self.right_it.next();
+          } else {
+            break;
+          }
+        }
+      } else {
+        // Overlapping case between l and r
+        // TODO: I had to clone it because I return Range<T> but here this iterator could just return a &Range<T>
+        let range = l.clone();
+        self.left = self.left_it.next();
+        // We return that range from left_it, it should give us all the ranges from left_it
+        // that are overlapping with right_it
+        return Some(range);
+      }
+    }
+    None
+  }
+
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    self.left_it.size_hint()
+  }
+}
+
+impl<T, Q, I1, I2> RangeMOCIterator<T> for OverlapRangeIter<T, Q, I1, I2>
+where
+  T: Idx,
+  Q: MocQty<T>,
+  I1: RangeMOCIterator<T, Qty = Q>,
+  I2: RangeMOCIterator<T, Qty = Q>,
+{
+  type Qty = Q;
+
+  fn peek_last(&self) -> Option<&Range<T>> {
+    // We could have considered the case in which the upper bound is the same for both inputs
+    None
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::fs::File;
+  use std::io::BufReader;
+  use std::path::PathBuf;
+
+  use crate::deser::fits::{from_fits_ivoa, MocIdxType, MocQtyType, MocType};
+  use crate::moc::range::op::overlap::overlapped_by;
+  use crate::moc::range::RangeMOC;
+  use crate::moc::{CellMOCIntoIterator, CellMOCIterator, HasMaxDepth, RangeMOCIntoIterator};
+  use crate::qty::Hpx;
+
+  fn load_moc(filename: &str) -> RangeMOC<u32, Hpx<u32>> {
+    let path_buf1 = PathBuf::from(format!("resources/{}", filename));
+    let path_buf2 = PathBuf::from(format!("../resources/{}", filename));
+    let file = File::open(&path_buf1)
+      .or_else(|_| File::open(&path_buf2))
+      .unwrap();
+    let reader = BufReader::new(file);
+    match from_fits_ivoa(reader) {
+      Ok(MocIdxType::U32(MocQtyType::Hpx(MocType::Ranges(moc)))) => {
+        let moc = RangeMOC::new(moc.depth_max(), moc.collect());
+        moc
+      }
+      Ok(MocIdxType::U32(MocQtyType::Hpx(MocType::Cells(moc)))) => {
+        let moc = RangeMOC::new(moc.depth_max(), moc.into_cell_moc_iter().ranges().collect());
+        moc
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  fn load_mocs() -> (RangeMOC<u32, Hpx<u32>>, RangeMOC<u32, Hpx<u32>>) {
+    let sdss = load_moc("V_147_sdss12.moc.fits");
+    let other = load_moc("CDS-I-125A-catalog_MOC.fits");
+    (sdss, other)
+  }
+
+  // we could also perform the operation without having first collected the iteartor we obtain from
+  // the FITS file
+  #[test]
+  fn overlap_it() {
+    let (moc_l, moc_r) = load_mocs();
+    let overlap_it = overlapped_by(
+      (&moc_l).into_range_moc_iter(),
+      (&moc_r).into_range_moc_iter(),
+    );
+    let overlap = RangeMOC::<u32, Hpx<u32>>::new(overlap_it.depth_max(), overlap_it.collect());
+
+    assert_eq!(
+      overlap.moc_ranges().0 .0.len() <= moc_l.moc_ranges().0 .0.len(),
+      true
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a overlapped_by_iter method in RangeMOC returning ranges of self that overlap ranges of another RangeMOC.

This would be useful to have that for aladin lite as it would be possible to on-the-fly draw cells of a MOC that overlap the MOC of the view.

PS: this is a draft so please do not merge (I still need to check in aladin lite if it works) but I would not mind a review. Especially I noticed that the iterators in op are returning owned Range<T> but maybe for the new Overlap one I could return &Range<T> because I just need to return the ranges of self that overlaps rhs i.e. I do not need to create new ones.